### PR TITLE
Novos serviços para ir buscar as temperaturas configuradas, e tambem …

### DIFF
--- a/ecoforest-proxy/README.md
+++ b/ecoforest-proxy/README.md
@@ -92,6 +92,51 @@ sensor:
         friendly_name: "Room Temperature"
         unit_of_measurement: "°C"
         value_template: "{{ state_attr('sensor.ecoforest', 'temperatura') }}"
+      ecoforest_aqs_temp:
+        entity_id: sensor.operationtemps
+        friendly_name: "Aqs Temperature"
+        unit_of_measurement: "°C"
+        value_template: "{{ state_attr('sensor.operationtemps', 'Ac') }}"
+      ecoforest_impulsao_temp:
+        entity_id: sensor.operationtemps
+        friendly_name: "Impulsao Temperature"
+        unit_of_measurement: "°C"
+        value_template: "{{ state_attr('sensor.operationtemps', 'Aa') }}"
+      ecoforest_retorno_temp:
+        entity_id: sensor.operationtemps
+        friendly_name: "Return Temperature"
+        unit_of_measurement: "°C"
+        value_template: "{{ state_attr('sensor.operationtemps', 'Ab') }}"
+      ecoforest_heating_temp:
+        entity_id: sensor.operationtemps
+        friendly_name: "Heating Temperature"
+        unit_of_measurement: "°C"
+        value_template: "{{ state_attr('sensor.operationtemps', 'Af') }}"
+      ecoforest_aqs_requested_temp:
+        entity_id: sensor.configtemps
+        friendly_name: "Aqs Requested Temperature"
+        unit_of_measurement: "°C"
+        value_template: "{{ state_attr('sensor.configtemps', 'Ba') }}"
+      ecoforest_ambiente_requested_temp:
+        entity_id: sensor.configtemps
+        friendly_name: "Ambiente Requested Temperature"
+        unit_of_measurement: "°C"
+        value_template: "{{ state_attr('sensor.configtemps', 'Be') }}"
+      ecoforest_delte_aqs_temp:
+        entity_id: sensor.configtemps
+        friendly_name: "Delta AQS Temperature"
+        unit_of_measurement: "°C"
+        value_template: "{{ state_attr('sensor.configtemps', 'Bc') }}"
+      ecoforest_requested_aqs_pump_temp:
+        entity_id: sensor.configtemps
+        friendly_name: "Requested AQS Pump Temperature"
+        unit_of_measurement: "°C"
+        value_template: "{{ state_attr('sensor.configtemps', 'Bj') }}"
+      ecoforest_heating_requested_pump_temp:
+        entity_id: sensor.configtemps
+        friendly_name: "Heating Requested Pump Temperature"
+        unit_of_measurement: "°C"
+        value_template: "{{ state_attr('sensor.configtemps', 'Bk') }}"
 ```
 ## Credits:
 

--- a/ecoforest-proxy/config.json
+++ b/ecoforest-proxy/config.json
@@ -8,6 +8,7 @@
 	"boot": "auto",
 	"options": {
 		"debug": "0",
+		"aquecimento": "0",
 		"proxy_port": "8998",
 		"ecoforest_host": "http://192.168.1.70",
 		"ecoforest_user": "",
@@ -15,6 +16,7 @@
 	},
 	"schema": {
 		"debug": "bool",
+		"aquecimento": "bool",
 		"proxy_port": "int",
 		"ecoforest_host": "str",
 		"ecoforest_user": "str",

--- a/ecoforest-proxy/ecoforest-proxy.py
+++ b/ecoforest-proxy/ecoforest-proxy.py
@@ -9,6 +9,7 @@ jdata = json.load(open('/data/options.json'))
 
 DEBUG = bool(jdata['debug'])
 DEFAULT_PORT = int(jdata['proxy_port'])
+AQUECIMENTO = bool(jdata['aquecimento'])
 
 host = str(jdata['ecoforest_host'])
 username = str(jdata['ecoforest_user'])
@@ -47,6 +48,21 @@ class EcoforestServer(BaseHTTPRequestHandler):
         else:
             self.send_error(500, 'Something went wrong here on the server side.')
 
+    def temps(self):
+        if DEBUG: logging.debug('GET temps')
+        temps = self.ecoforest_temps()
+        if temps:
+            self.send(temps)
+        else:
+            self.send_error(500, 'Something went wrong here on the server side.')
+
+    def config_temps(self):
+        if DEBUG: logging.debug('GET config temps')
+        config_temps = self.ecoforest_config_temps()
+        if config_temps:
+            self.send(config_temps)
+        else:
+            self.send_error(500, 'Something went wrong here on the server side.')
 
     def set_status(self, status):
         if DEBUG: logging.debug('SET STATUS: %s' % (status))
@@ -107,6 +123,18 @@ class EcoforestServer(BaseHTTPRequestHandler):
         data = self.ecoforest_call('idOperacion=1004&potencia=' + str(power_final))
         print(data)
         self.send(self.ecoforest_stats())
+
+    def ecoforest_temps(self):
+        if AQUECIMENTO:
+            temps = self.ecoforest_call('idOperacion=1129')
+            return temps
+        return
+
+    def ecoforest_config_temps(self):
+        if AQUECIMENTO:
+            temps = self.ecoforest_call('idOperacion=1130')
+            return temps
+        return
 
 
     def ecoforest_stats(self):
@@ -190,6 +218,8 @@ class EcoforestServer(BaseHTTPRequestHandler):
         dispatch = {
             '/healthcheck': self.healthcheck,
             '/ecoforest/fullstats': self.stats,
+            '/ecoforest/operationtemps': self.temps,
+            '/ecoforest/configtemps': self.config_temps,
             '/ecoforest/status': self.get_status,
             '/ecoforest/set_status': self.set_status,
             '/ecoforest/set_temp': self.set_temp,

--- a/ecoforest-proxy/ecoforest-proxy.py
+++ b/ecoforest-proxy/ecoforest-proxy.py
@@ -132,8 +132,8 @@ class EcoforestServer(BaseHTTPRequestHandler):
 
     def ecoforest_config_temps(self):
         if AQUECIMENTO:
-            temps = self.ecoforest_call('idOperacion=1130')
-            return temps
+            config_temps = self.ecoforest_call('idOperacion=1130')
+            return config_temps
         return
 
 


### PR DESCRIPTION
Descobri que existem 2 pedidos adicionais que se podem fazer, e dessa forma termos acesso ás temperaturas que a caldeira tem, ora de sensores, ora configuradas.
Não tenho conhecimentos de Python, por isso não sei se tudo o que fiz está correcto.
Mas a ideia é caso se configure que existe aquecimento, então ficam disponiveis esses 2 serviços.

Obrigado